### PR TITLE
Rename Theme.Skeleton to Theme.App

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Skeleton.Starting"
+        android:theme="@style/Theme.App.Starting"
         tools:targetApi="33">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Skeleton" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.App" parent="android:Theme.Material.NoActionBar" />
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Skeleton" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.App" parent="android:Theme.Material.Light.NoActionBar" />
 
-    <style name="Theme.Skeleton.Starting" parent="Theme.SplashScreen">
-        <item name="postSplashScreenTheme">@style/Theme.Skeleton</item>
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="postSplashScreenTheme">@style/Theme.App</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
         <item name="windowSplashScreenBackground">@color/splash_screen_background</item>
     </style>


### PR DESCRIPTION
`App` is a better default name for the application theme and is universal. So there's no more need to change it after applying the template.