### PR TITLE
Enable enableBuildConfigAsBytecode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+android.enableBuildConfigAsBytecode=true


### PR DESCRIPTION
When android.enableBuildConfigAsBytecode=true, the BuildConfig file isn’t generated as a Java file, but as a compiled file. This avoids the Java compilation step!

See: https://medium.com/androiddevelopers/5-ways-to-prepare-your-app-build-for-android-studio-flamingo-release-da34616bb946